### PR TITLE
feat: add i18n tooltips across UI components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vian",
-  "version": "0.14.2",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vian",
-      "version": "0.14.2",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/src/renderer/src/components/ShotDetail.vue
+++ b/src/renderer/src/components/ShotDetail.vue
@@ -40,14 +40,18 @@
           <template #label>
             <div>
               {{ $t('components.shotDetail.lockSegment') }}
-              <v-tooltip location="bottom">
-                <template #activator="{ props: activatorProps }">
-                  <v-btn density="compact" variant="text" icon v-bind="activatorProps">
-                    <v-icon>mdi-information-outline</v-icon>
-                  </v-btn>
-                </template>
-                {{ $t('components.shotDetail.lockHelp') }}
-              </v-tooltip>
+              <v-btn
+                v-tooltip="{
+                  text: $t('components.shotDetail.lockHelp'),
+                  location: 'bottom'
+                }"
+                density="compact"
+                variant="text"
+                icon
+                :aria-label="$t('components.shotDetail.lockHelp')"
+              >
+                <v-icon>mdi-information-outline</v-icon>
+              </v-btn>
             </div>
           </template>
         </v-checkbox>

--- a/src/renderer/src/components/Timelines.vue
+++ b/src/renderer/src/components/Timelines.vue
@@ -1,35 +1,56 @@
 <template>
   <v-sheet class="d-flex flex-1-1 flex-column height-min-0">
     <div>
-      <v-btn
-        density="compact"
-        variant="text"
-        :disabled="!segmentDeletable"
-        icon
-        @click="segmentDelete"
-      >
-        <v-icon>mdi-delete</v-icon>
-      </v-btn>
+      <v-tooltip :text="$t('components.timelines.tooltips.deleteSelectedSegment')" location="bottom">
+        <template #activator="{ props }">
+          <span v-bind="props">
+            <v-btn
+              density="compact"
+              variant="text"
+              :disabled="!segmentDeletable"
+              icon
+              :aria-label="$t('components.timelines.tooltips.deleteSelectedSegment')"
+              @click="segmentDelete"
+            >
+              <v-icon>mdi-delete</v-icon>
+            </v-btn>
+          </span>
+        </template>
+      </v-tooltip>
 
-      <v-btn
-        density="compact"
-        variant="text"
-        :disabled="!segmentSplitable"
-        icon
-        @click="segmentSplit"
-      >
-        <v-icon>mdi-table-split-cell</v-icon>
-      </v-btn>
+      <v-tooltip :text="$t('components.timelines.tooltips.splitSelectedSegment')" location="bottom">
+        <template #activator="{ props }">
+          <span v-bind="props">
+            <v-btn
+              density="compact"
+              variant="text"
+              :disabled="!segmentSplitable"
+              icon
+              :aria-label="$t('components.timelines.tooltips.splitSelectedSegment')"
+              @click="segmentSplit"
+            >
+              <v-icon>mdi-table-split-cell</v-icon>
+            </v-btn>
+          </span>
+        </template>
+      </v-tooltip>
 
-      <v-btn
-        density="compact"
-        variant="text"
-        :disabled="!segmentMergable"
-        icon
-        @click="segmentMerge"
-      >
-        <v-icon>mdi-table-merge-cells</v-icon>
-      </v-btn>
+      <v-tooltip :text="$t('components.timelines.tooltips.mergeSelectedSegments')" location="bottom">
+        <template #activator="{ props }">
+          <span v-bind="props">
+            <v-btn
+              density="compact"
+              variant="text"
+              :disabled="!segmentMergable"
+              icon
+              :aria-label="$t('components.timelines.tooltips.mergeSelectedSegments')"
+              @click="segmentMerge"
+            >
+              <v-icon>mdi-table-merge-cells</v-icon>
+            </v-btn>
+          </span>
+        </template>
+      </v-tooltip>
     </div>
 
     <div id="timelineAxesContainer"></div>
@@ -61,15 +82,28 @@
                 >
                   <template #append>
                     <v-list-item-action start>
-                      <v-btn
+                      <v-tooltip
                         v-if="timeline.categories"
-                        icon
-                        variant="text"
-                        density="compact"
-                        @click="timeline.visible = !timeline.visible"
+                        :text="timeline.visible
+                          ? $t('components.timelines.tooltips.hideCategories')
+                          : $t('components.timelines.tooltips.showCategories')"
+                        location="bottom"
                       >
-                        <v-icon>mdi-expand-all</v-icon>
-                      </v-btn>
+                        <template #activator="{ props }">
+                          <v-btn
+                            icon
+                            variant="text"
+                            density="compact"
+                            v-bind="props"
+                            :aria-label="timeline.visible
+                              ? $t('components.timelines.tooltips.hideCategories')
+                              : $t('components.timelines.tooltips.showCategories')"
+                            @click="timeline.visible = !timeline.visible"
+                          >
+                            <v-icon>mdi-expand-all</v-icon>
+                          </v-btn>
+                        </template>
+                      </v-tooltip>
 
                       <v-menu>
                         <template #activator="{ props }">

--- a/src/renderer/src/components/Timelines.vue
+++ b/src/renderer/src/components/Timelines.vue
@@ -1,62 +1,59 @@
 <template>
   <v-sheet class="d-flex flex-1-1 flex-column height-min-0">
     <div>
-      <v-tooltip
-        :text="$t('components.timelines.tooltips.deleteSelectedSegment')"
-        location="bottom"
+      <span
+        v-tooltip="{
+          text: $t('components.timelines.tooltips.deleteSelectedSegment'),
+          location: 'bottom'
+        }"
       >
-        <template #activator="{ props }">
-          <span v-bind="props">
-            <v-btn
-              density="compact"
-              variant="text"
-              :disabled="!segmentDeletable"
-              icon
-              :aria-label="$t('components.timelines.tooltips.deleteSelectedSegment')"
-              @click="segmentDelete"
-            >
-              <v-icon>mdi-delete</v-icon>
-            </v-btn>
-          </span>
-        </template>
-      </v-tooltip>
+        <v-btn
+          density="compact"
+          variant="text"
+          :disabled="!segmentDeletable"
+          icon
+          :aria-label="$t('components.timelines.tooltips.deleteSelectedSegment')"
+          @click="segmentDelete"
+        >
+          <v-icon>mdi-delete</v-icon>
+        </v-btn>
+      </span>
 
-      <v-tooltip :text="$t('components.timelines.tooltips.splitSelectedSegment')" location="bottom">
-        <template #activator="{ props }">
-          <span v-bind="props">
-            <v-btn
-              density="compact"
-              variant="text"
-              :disabled="!segmentSplitable"
-              icon
-              :aria-label="$t('components.timelines.tooltips.splitSelectedSegment')"
-              @click="segmentSplit"
-            >
-              <v-icon>mdi-table-split-cell</v-icon>
-            </v-btn>
-          </span>
-        </template>
-      </v-tooltip>
-
-      <v-tooltip
-        :text="$t('components.timelines.tooltips.mergeSelectedSegments')"
-        location="bottom"
+      <span
+        v-tooltip="{
+          text: $t('components.timelines.tooltips.splitSelectedSegment'),
+          location: 'bottom'
+        }"
       >
-        <template #activator="{ props }">
-          <span v-bind="props">
-            <v-btn
-              density="compact"
-              variant="text"
-              :disabled="!segmentMergable"
-              icon
-              :aria-label="$t('components.timelines.tooltips.mergeSelectedSegments')"
-              @click="segmentMerge"
-            >
-              <v-icon>mdi-table-merge-cells</v-icon>
-            </v-btn>
-          </span>
-        </template>
-      </v-tooltip>
+        <v-btn
+          density="compact"
+          variant="text"
+          :disabled="!segmentSplitable"
+          icon
+          :aria-label="$t('components.timelines.tooltips.splitSelectedSegment')"
+          @click="segmentSplit"
+        >
+          <v-icon>mdi-table-split-cell</v-icon>
+        </v-btn>
+      </span>
+
+      <span
+        v-tooltip="{
+          text: $t('components.timelines.tooltips.mergeSelectedSegments'),
+          location: 'bottom'
+        }"
+      >
+        <v-btn
+          density="compact"
+          variant="text"
+          :disabled="!segmentMergable"
+          icon
+          :aria-label="$t('components.timelines.tooltips.mergeSelectedSegments')"
+          @click="segmentMerge"
+        >
+          <v-icon>mdi-table-merge-cells</v-icon>
+        </v-btn>
+      </span>
     </div>
 
     <div id="timelineAxesContainer"></div>
@@ -88,32 +85,26 @@
                 >
                   <template #append>
                     <v-list-item-action start>
-                      <v-tooltip
+                      <v-btn
                         v-if="timeline.categories"
-                        :text="
+                        v-tooltip="{
+                          text: timeline.visible
+                            ? $t('components.timelines.tooltips.hideCategories')
+                            : $t('components.timelines.tooltips.showCategories'),
+                          location: 'bottom'
+                        }"
+                        icon
+                        variant="text"
+                        density="compact"
+                        :aria-label="
                           timeline.visible
                             ? $t('components.timelines.tooltips.hideCategories')
                             : $t('components.timelines.tooltips.showCategories')
                         "
-                        location="bottom"
+                        @click="timeline.visible = !timeline.visible"
                       >
-                        <template #activator="{ props }">
-                          <v-btn
-                            icon
-                            variant="text"
-                            density="compact"
-                            v-bind="props"
-                            :aria-label="
-                              timeline.visible
-                                ? $t('components.timelines.tooltips.hideCategories')
-                                : $t('components.timelines.tooltips.showCategories')
-                            "
-                            @click="timeline.visible = !timeline.visible"
-                          >
-                            <v-icon>mdi-expand-all</v-icon>
-                          </v-btn>
-                        </template>
-                      </v-tooltip>
+                        <v-icon>mdi-expand-all</v-icon>
+                      </v-btn>
 
                       <v-menu>
                         <template #activator="{ props }">

--- a/src/renderer/src/components/Timelines.vue
+++ b/src/renderer/src/components/Timelines.vue
@@ -1,7 +1,10 @@
 <template>
   <v-sheet class="d-flex flex-1-1 flex-column height-min-0">
     <div>
-      <v-tooltip :text="$t('components.timelines.tooltips.deleteSelectedSegment')" location="bottom">
+      <v-tooltip
+        :text="$t('components.timelines.tooltips.deleteSelectedSegment')"
+        location="bottom"
+      >
         <template #activator="{ props }">
           <span v-bind="props">
             <v-btn
@@ -35,7 +38,10 @@
         </template>
       </v-tooltip>
 
-      <v-tooltip :text="$t('components.timelines.tooltips.mergeSelectedSegments')" location="bottom">
+      <v-tooltip
+        :text="$t('components.timelines.tooltips.mergeSelectedSegments')"
+        location="bottom"
+      >
         <template #activator="{ props }">
           <span v-bind="props">
             <v-btn
@@ -84,9 +90,11 @@
                     <v-list-item-action start>
                       <v-tooltip
                         v-if="timeline.categories"
-                        :text="timeline.visible
-                          ? $t('components.timelines.tooltips.hideCategories')
-                          : $t('components.timelines.tooltips.showCategories')"
+                        :text="
+                          timeline.visible
+                            ? $t('components.timelines.tooltips.hideCategories')
+                            : $t('components.timelines.tooltips.showCategories')
+                        "
                         location="bottom"
                       >
                         <template #activator="{ props }">
@@ -95,9 +103,11 @@
                             variant="text"
                             density="compact"
                             v-bind="props"
-                            :aria-label="timeline.visible
-                              ? $t('components.timelines.tooltips.hideCategories')
-                              : $t('components.timelines.tooltips.showCategories')"
+                            :aria-label="
+                              timeline.visible
+                                ? $t('components.timelines.tooltips.hideCategories')
+                                : $t('components.timelines.tooltips.showCategories')
+                            "
                             @click="timeline.visible = !timeline.visible"
                           >
                             <v-icon>mdi-expand-all</v-icon>

--- a/src/renderer/src/components/VideoPlayer.vue
+++ b/src/renderer/src/components/VideoPlayer.vue
@@ -21,27 +21,88 @@
       <div class="d-flex flex-0-0 flex-column">
         <div class="d-flex justify-space-between min-wide-control px-2">
           <div class="align-center d-flex">
-            <v-btn density="comfortable" size="small" icon @click="jumpBackward">
-              <v-icon>mdi-skip-backward</v-icon>
-            </v-btn>
+            <v-tooltip :text="$t('components.videoPlayer.tooltips.jumpBackward')" location="top">
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="$t('components.videoPlayer.tooltips.jumpBackward')"
+                  @click="jumpBackward"
+                >
+                  <v-icon>mdi-skip-backward</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
-            <v-btn density="comfortable" size="small" icon @click="backwardClicked">
-              <v-icon>mdi-step-backward</v-icon>
-            </v-btn>
+            <v-tooltip :text="$t('components.videoPlayer.tooltips.previousFrame')" location="top">
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="$t('components.videoPlayer.tooltips.previousFrame')"
+                  @click="backwardClicked"
+                >
+                  <v-icon>mdi-step-backward</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
-            <v-btn density="comfortable" size="small" icon @click="playPauseClicked">
-              <v-icon v-if="playingState">mdi-pause</v-icon>
+            <v-tooltip
+              :text="playingState
+                ? $t('components.videoPlayer.tooltips.pausePlayback')
+                : $t('components.videoPlayer.tooltips.playVideo')"
+              location="top"
+            >
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="playingState
+                    ? $t('components.videoPlayer.tooltips.pausePlayback')
+                    : $t('components.videoPlayer.tooltips.playVideo')"
+                  @click="playPauseClicked"
+                >
+                  <v-icon v-if="playingState">mdi-pause</v-icon>
+                  <v-icon v-else>mdi-play</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
-              <v-icon v-else>mdi-play</v-icon>
-            </v-btn>
+            <v-tooltip :text="$t('components.videoPlayer.tooltips.nextFrame')" location="top">
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="$t('components.videoPlayer.tooltips.nextFrame')"
+                  @click="forwardClicked"
+                >
+                  <v-icon>mdi-step-forward</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
-            <v-btn density="comfortable" size="small" icon @click="forwardClicked">
-              <v-icon>mdi-step-forward</v-icon>
-            </v-btn>
-
-            <v-btn density="comfortable" size="small" icon @click="jumpForward">
-              <v-icon>mdi-skip-forward</v-icon>
-            </v-btn>
+            <v-tooltip :text="$t('components.videoPlayer.tooltips.jumpForward')" location="top">
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="$t('components.videoPlayer.tooltips.jumpForward')"
+                  @click="jumpForward"
+                >
+                  <v-icon>mdi-skip-forward</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
             <v-chip
               v-tooltip="{
@@ -58,24 +119,62 @@
           </div>
 
           <div class="align-center d-flex">
-            <v-btn
+            <v-tooltip
               v-if="pictureInPictureEnabled"
-              density="comfortable"
-              size="small"
-              icon
-              @click="pictureInPictureClicked"
+              :text="$t('components.videoPlayer.tooltips.pictureInPicture')"
+              location="top"
             >
-              <v-icon>mdi-picture-in-picture-top-right</v-icon>
-            </v-btn>
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="$t('components.videoPlayer.tooltips.pictureInPicture')"
+                  @click="pictureInPictureClicked"
+                >
+                  <v-icon>mdi-picture-in-picture-top-right</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
-            <v-btn density="comfortable" size="small" icon @click="screenshotClicked">
-              <v-icon>mdi-camera</v-icon>
-            </v-btn>
+            <v-tooltip :text="$t('components.videoPlayer.tooltips.takeScreenshot')" location="top">
+              <template #activator="{ props }">
+                <v-btn
+                  density="comfortable"
+                  size="small"
+                  icon
+                  v-bind="props"
+                  :aria-label="$t('components.videoPlayer.tooltips.takeScreenshot')"
+                  @click="screenshotClicked"
+                >
+                  <v-icon>mdi-camera</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
 
             <div class="volume-control">
-              <v-btn density="comfortable" size="small" icon @click.stop="toggleVolumeSlider">
-                <v-icon>{{ volume === 0 ? 'mdi-volume-mute' : 'mdi-volume-high' }}</v-icon>
-              </v-btn>
+              <v-tooltip
+                :text="volume === 0
+                  ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
+                  : $t('components.videoPlayer.tooltips.adjustVolume')"
+                location="top"
+              >
+                <template #activator="{ props }">
+                  <v-btn
+                    density="comfortable"
+                    size="small"
+                    icon
+                    v-bind="props"
+                    :aria-label="volume === 0
+                      ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
+                      : $t('components.videoPlayer.tooltips.adjustVolume')"
+                    @click.stop="toggleVolumeSlider"
+                  >
+                    <v-icon>{{ volume === 0 ? 'mdi-volume-mute' : 'mdi-volume-high' }}</v-icon>
+                  </v-btn>
+                </template>
+              </v-tooltip>
 
               <v-menu
                 v-model="showVolumeSlider"
@@ -103,11 +202,27 @@
               </v-menu>
             </div>
 
-            <v-btn v-if="undoableStore.subtitles !== null" icon @click="toggleSubtitles">
-              <v-icon v-if="undoableStore.subtitlesVisible">mdi-subtitles</v-icon>
-
-              <v-icon v-else>mdi-subtitles-outline</v-icon>
-            </v-btn>
+            <v-tooltip
+              v-if="undoableStore.subtitles !== null"
+              :text="undoableStore.subtitlesVisible
+                ? $t('components.videoPlayer.tooltips.hideSubtitles')
+                : $t('components.videoPlayer.tooltips.showSubtitles')"
+              location="top"
+            >
+              <template #activator="{ props }">
+                <v-btn
+                  icon
+                  v-bind="props"
+                  :aria-label="undoableStore.subtitlesVisible
+                    ? $t('components.videoPlayer.tooltips.hideSubtitles')
+                    : $t('components.videoPlayer.tooltips.showSubtitles')"
+                  @click="toggleSubtitles"
+                >
+                  <v-icon v-if="undoableStore.subtitlesVisible">mdi-subtitles</v-icon>
+                  <v-icon v-else>mdi-subtitles-outline</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
           </div>
         </div>
 

--- a/src/renderer/src/components/VideoPlayer.vue
+++ b/src/renderer/src/components/VideoPlayer.vue
@@ -52,9 +52,11 @@
             </v-tooltip>
 
             <v-tooltip
-              :text="playingState
-                ? $t('components.videoPlayer.tooltips.pausePlayback')
-                : $t('components.videoPlayer.tooltips.playVideo')"
+              :text="
+                playingState
+                  ? $t('components.videoPlayer.tooltips.pausePlayback')
+                  : $t('components.videoPlayer.tooltips.playVideo')
+              "
               location="top"
             >
               <template #activator="{ props }">
@@ -63,12 +65,15 @@
                   size="small"
                   icon
                   v-bind="props"
-                  :aria-label="playingState
-                    ? $t('components.videoPlayer.tooltips.pausePlayback')
-                    : $t('components.videoPlayer.tooltips.playVideo')"
+                  :aria-label="
+                    playingState
+                      ? $t('components.videoPlayer.tooltips.pausePlayback')
+                      : $t('components.videoPlayer.tooltips.playVideo')
+                  "
                   @click="playPauseClicked"
                 >
                   <v-icon v-if="playingState">mdi-pause</v-icon>
+
                   <v-icon v-else>mdi-play</v-icon>
                 </v-btn>
               </template>
@@ -155,9 +160,11 @@
 
             <div class="volume-control">
               <v-tooltip
-                :text="volume === 0
-                  ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
-                  : $t('components.videoPlayer.tooltips.adjustVolume')"
+                :text="
+                  volume === 0
+                    ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
+                    : $t('components.videoPlayer.tooltips.adjustVolume')
+                "
                 location="top"
               >
                 <template #activator="{ props }">
@@ -166,9 +173,11 @@
                     size="small"
                     icon
                     v-bind="props"
-                    :aria-label="volume === 0
-                      ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
-                      : $t('components.videoPlayer.tooltips.adjustVolume')"
+                    :aria-label="
+                      volume === 0
+                        ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
+                        : $t('components.videoPlayer.tooltips.adjustVolume')
+                    "
                     @click.stop="toggleVolumeSlider"
                   >
                     <v-icon>{{ volume === 0 ? 'mdi-volume-mute' : 'mdi-volume-high' }}</v-icon>
@@ -204,21 +213,26 @@
 
             <v-tooltip
               v-if="undoableStore.subtitles !== null"
-              :text="undoableStore.subtitlesVisible
-                ? $t('components.videoPlayer.tooltips.hideSubtitles')
-                : $t('components.videoPlayer.tooltips.showSubtitles')"
+              :text="
+                undoableStore.subtitlesVisible
+                  ? $t('components.videoPlayer.tooltips.hideSubtitles')
+                  : $t('components.videoPlayer.tooltips.showSubtitles')
+              "
               location="top"
             >
               <template #activator="{ props }">
                 <v-btn
                   icon
                   v-bind="props"
-                  :aria-label="undoableStore.subtitlesVisible
-                    ? $t('components.videoPlayer.tooltips.hideSubtitles')
-                    : $t('components.videoPlayer.tooltips.showSubtitles')"
+                  :aria-label="
+                    undoableStore.subtitlesVisible
+                      ? $t('components.videoPlayer.tooltips.hideSubtitles')
+                      : $t('components.videoPlayer.tooltips.showSubtitles')
+                  "
                   @click="toggleSubtitles"
                 >
                   <v-icon v-if="undoableStore.subtitlesVisible">mdi-subtitles</v-icon>
+
                   <v-icon v-else>mdi-subtitles-outline</v-icon>
                 </v-btn>
               </template>

--- a/src/renderer/src/components/VideoPlayer.vue
+++ b/src/renderer/src/components/VideoPlayer.vue
@@ -21,93 +21,83 @@
       <div class="d-flex flex-0-0 flex-column">
         <div class="d-flex justify-space-between min-wide-control px-2">
           <div class="align-center d-flex">
-            <v-tooltip :text="$t('components.videoPlayer.tooltips.jumpBackward')" location="top">
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="$t('components.videoPlayer.tooltips.jumpBackward')"
-                  @click="jumpBackward"
-                >
-                  <v-icon>mdi-skip-backward</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+            <v-btn
+              v-tooltip="{
+                text: $t('components.videoPlayer.tooltips.jumpBackward'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="$t('components.videoPlayer.tooltips.jumpBackward')"
+              @click="jumpBackward"
+            >
+              <v-icon>mdi-skip-backward</v-icon>
+            </v-btn>
 
-            <v-tooltip :text="$t('components.videoPlayer.tooltips.previousFrame')" location="top">
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="$t('components.videoPlayer.tooltips.previousFrame')"
-                  @click="backwardClicked"
-                >
-                  <v-icon>mdi-step-backward</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+            <v-btn
+              v-tooltip="{
+                text: $t('components.videoPlayer.tooltips.previousFrame'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="$t('components.videoPlayer.tooltips.previousFrame')"
+              @click="backwardClicked"
+            >
+              <v-icon>mdi-step-backward</v-icon>
+            </v-btn>
 
-            <v-tooltip
-              :text="
+            <v-btn
+              v-tooltip="{
+                text: playingState
+                  ? $t('components.videoPlayer.tooltips.pausePlayback')
+                  : $t('components.videoPlayer.tooltips.playVideo'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="
                 playingState
                   ? $t('components.videoPlayer.tooltips.pausePlayback')
                   : $t('components.videoPlayer.tooltips.playVideo')
               "
-              location="top"
+              @click="playPauseClicked"
             >
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="
-                    playingState
-                      ? $t('components.videoPlayer.tooltips.pausePlayback')
-                      : $t('components.videoPlayer.tooltips.playVideo')
-                  "
-                  @click="playPauseClicked"
-                >
-                  <v-icon v-if="playingState">mdi-pause</v-icon>
+              <v-icon v-if="playingState">mdi-pause</v-icon>
 
-                  <v-icon v-else>mdi-play</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+              <v-icon v-else>mdi-play</v-icon>
+            </v-btn>
 
-            <v-tooltip :text="$t('components.videoPlayer.tooltips.nextFrame')" location="top">
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="$t('components.videoPlayer.tooltips.nextFrame')"
-                  @click="forwardClicked"
-                >
-                  <v-icon>mdi-step-forward</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+            <v-btn
+              v-tooltip="{
+                text: $t('components.videoPlayer.tooltips.nextFrame'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="$t('components.videoPlayer.tooltips.nextFrame')"
+              @click="forwardClicked"
+            >
+              <v-icon>mdi-step-forward</v-icon>
+            </v-btn>
 
-            <v-tooltip :text="$t('components.videoPlayer.tooltips.jumpForward')" location="top">
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="$t('components.videoPlayer.tooltips.jumpForward')"
-                  @click="jumpForward"
-                >
-                  <v-icon>mdi-skip-forward</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+            <v-btn
+              v-tooltip="{
+                text: $t('components.videoPlayer.tooltips.jumpForward'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="$t('components.videoPlayer.tooltips.jumpForward')"
+              @click="jumpForward"
+            >
+              <v-icon>mdi-skip-forward</v-icon>
+            </v-btn>
 
             <v-chip
               v-tooltip="{
@@ -124,66 +114,56 @@
           </div>
 
           <div class="align-center d-flex">
-            <v-tooltip
+            <v-btn
               v-if="pictureInPictureEnabled"
-              :text="$t('components.videoPlayer.tooltips.pictureInPicture')"
-              location="top"
+              v-tooltip="{
+                text: $t('components.videoPlayer.tooltips.pictureInPicture'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="$t('components.videoPlayer.tooltips.pictureInPicture')"
+              @click="pictureInPictureClicked"
             >
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="$t('components.videoPlayer.tooltips.pictureInPicture')"
-                  @click="pictureInPictureClicked"
-                >
-                  <v-icon>mdi-picture-in-picture-top-right</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+              <v-icon>mdi-picture-in-picture-top-right</v-icon>
+            </v-btn>
 
-            <v-tooltip :text="$t('components.videoPlayer.tooltips.takeScreenshot')" location="top">
-              <template #activator="{ props }">
-                <v-btn
-                  density="comfortable"
-                  size="small"
-                  icon
-                  v-bind="props"
-                  :aria-label="$t('components.videoPlayer.tooltips.takeScreenshot')"
-                  @click="screenshotClicked"
-                >
-                  <v-icon>mdi-camera</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+            <v-btn
+              v-tooltip="{
+                text: $t('components.videoPlayer.tooltips.takeScreenshot'),
+                location: 'top'
+              }"
+              density="comfortable"
+              size="small"
+              icon
+              :aria-label="$t('components.videoPlayer.tooltips.takeScreenshot')"
+              @click="screenshotClicked"
+            >
+              <v-icon>mdi-camera</v-icon>
+            </v-btn>
 
             <div class="volume-control">
-              <v-tooltip
-                :text="
+              <v-btn
+                v-tooltip="{
+                  text:
+                    volume === 0
+                      ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
+                      : $t('components.videoPlayer.tooltips.adjustVolume'),
+                  location: 'top'
+                }"
+                density="comfortable"
+                size="small"
+                icon
+                :aria-label="
                   volume === 0
                     ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
                     : $t('components.videoPlayer.tooltips.adjustVolume')
                 "
-                location="top"
+                @click.stop="toggleVolumeSlider"
               >
-                <template #activator="{ props }">
-                  <v-btn
-                    density="comfortable"
-                    size="small"
-                    icon
-                    v-bind="props"
-                    :aria-label="
-                      volume === 0
-                        ? $t('components.videoPlayer.tooltips.unmuteOrAdjustVolume')
-                        : $t('components.videoPlayer.tooltips.adjustVolume')
-                    "
-                    @click.stop="toggleVolumeSlider"
-                  >
-                    <v-icon>{{ volume === 0 ? 'mdi-volume-mute' : 'mdi-volume-high' }}</v-icon>
-                  </v-btn>
-                </template>
-              </v-tooltip>
+                <v-icon>{{ volume === 0 ? 'mdi-volume-mute' : 'mdi-volume-high' }}</v-icon>
+              </v-btn>
 
               <v-menu
                 v-model="showVolumeSlider"
@@ -211,32 +191,26 @@
               </v-menu>
             </div>
 
-            <v-tooltip
+            <v-btn
               v-if="undoableStore.subtitles !== null"
-              :text="
+              v-tooltip="{
+                text: undoableStore.subtitlesVisible
+                  ? $t('components.videoPlayer.tooltips.hideSubtitles')
+                  : $t('components.videoPlayer.tooltips.showSubtitles'),
+                location: 'top'
+              }"
+              icon
+              :aria-label="
                 undoableStore.subtitlesVisible
                   ? $t('components.videoPlayer.tooltips.hideSubtitles')
                   : $t('components.videoPlayer.tooltips.showSubtitles')
               "
-              location="top"
+              @click="toggleSubtitles"
             >
-              <template #activator="{ props }">
-                <v-btn
-                  icon
-                  v-bind="props"
-                  :aria-label="
-                    undoableStore.subtitlesVisible
-                      ? $t('components.videoPlayer.tooltips.hideSubtitles')
-                      : $t('components.videoPlayer.tooltips.showSubtitles')
-                  "
-                  @click="toggleSubtitles"
-                >
-                  <v-icon v-if="undoableStore.subtitlesVisible">mdi-subtitles</v-icon>
+              <v-icon v-if="undoableStore.subtitlesVisible">mdi-subtitles</v-icon>
 
-                  <v-icon v-else>mdi-subtitles-outline</v-icon>
-                </v-btn>
-              </template>
-            </v-tooltip>
+              <v-icon v-else>mdi-subtitles-outline</v-icon>
+            </v-btn>
           </div>
         </div>
 
@@ -290,6 +264,7 @@ export default {
     'tempStore.playJumpPosition'(newValue) {
       // Use a proxy value because updating currentTime based on playPosition
       // directly is prone to timing issues
+
       if (newValue !== null) {
         this.$refs.video.currentTime = newValue
         this.tempStore.playPosition = newValue
@@ -434,6 +409,7 @@ export default {
 
     toggleVolumeSlider(event) {
       // Don't show slider if it's a double click
+
       if (event?.detail === 2) return
       this.showVolumeSlider = !this.showVolumeSlider
     },
@@ -474,6 +450,7 @@ video {
 }
 .volume-slider :deep(> .v-input__control) {
   /* min height sets the height of the slider here */
+
   min-height: 80px;
 }
 #video-grid {

--- a/src/renderer/src/components/VocabularyDialogListItem.vue
+++ b/src/renderer/src/components/VocabularyDialogListItem.vue
@@ -16,7 +16,10 @@
 
     <template #append>
       <div v-if="isEditing" class="d-flex">
-        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.save')" location="bottom">
+        <v-tooltip
+          :text="$t('components.vocabularyDialogListItem.tooltips.save')"
+          location="bottom"
+        >
           <template #activator="{ props }">
             <v-btn
               icon="mdi-check"
@@ -29,7 +32,10 @@
           </template>
         </v-tooltip>
 
-        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.cancel')" location="bottom">
+        <v-tooltip
+          :text="$t('components.vocabularyDialogListItem.tooltips.cancel')"
+          location="bottom"
+        >
           <template #activator="{ props }">
             <v-btn
               icon="mdi-close"
@@ -44,7 +50,10 @@
       </div>
 
       <div v-else class="d-flex">
-        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.editItem')" location="bottom">
+        <v-tooltip
+          :text="$t('components.vocabularyDialogListItem.tooltips.editItem')"
+          location="bottom"
+        >
           <template #activator="{ props }">
             <v-btn
               icon="mdi-pencil"
@@ -56,7 +65,12 @@
             />
           </template>
         </v-tooltip>
-        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.exportItem')" location="bottom" v-if="showExport">
+
+        <v-tooltip
+          v-if="showExport"
+          :text="$t('components.vocabularyDialogListItem.tooltips.exportItem')"
+          location="bottom"
+        >
           <template #activator="{ props }">
             <v-btn
               icon="mdi-file-export"
@@ -69,7 +83,10 @@
           </template>
         </v-tooltip>
 
-        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.deleteItem')" location="bottom">
+        <v-tooltip
+          :text="$t('components.vocabularyDialogListItem.tooltips.deleteItem')"
+          location="bottom"
+        >
           <template #activator="{ props }">
             <v-btn
               icon="mdi-trash-can"

--- a/src/renderer/src/components/VocabularyDialogListItem.vue
+++ b/src/renderer/src/components/VocabularyDialogListItem.vue
@@ -16,88 +16,68 @@
 
     <template #append>
       <div v-if="isEditing" class="d-flex">
-        <v-tooltip
-          :text="$t('components.vocabularyDialogListItem.tooltips.save')"
-          location="bottom"
-        >
-          <template #activator="{ props }">
-            <v-btn
-              icon="mdi-check"
-              variant="text"
-              size="small"
-              v-bind="props"
-              :aria-label="$t('components.vocabularyDialogListItem.tooltips.save')"
-              @click.stop="$emit('save', editValue)"
-            />
-          </template>
-        </v-tooltip>
+        <v-btn
+          v-tooltip="{
+            text: $t('components.vocabularyDialogListItem.tooltips.save'),
+            location: 'bottom'
+          }"
+          icon="mdi-check"
+          variant="text"
+          size="small"
+          :aria-label="$t('components.vocabularyDialogListItem.tooltips.save')"
+          @click.stop="$emit('save', editValue)"
+        />
 
-        <v-tooltip
-          :text="$t('components.vocabularyDialogListItem.tooltips.cancel')"
-          location="bottom"
-        >
-          <template #activator="{ props }">
-            <v-btn
-              icon="mdi-close"
-              variant="text"
-              size="small"
-              v-bind="props"
-              :aria-label="$t('components.vocabularyDialogListItem.tooltips.cancel')"
-              @click.stop="$emit('cancel')"
-            />
-          </template>
-        </v-tooltip>
+        <v-btn
+          v-tooltip="{
+            text: $t('components.vocabularyDialogListItem.tooltips.cancel'),
+            location: 'bottom'
+          }"
+          icon="mdi-close"
+          variant="text"
+          size="small"
+          :aria-label="$t('components.vocabularyDialogListItem.tooltips.cancel')"
+          @click.stop="$emit('cancel')"
+        />
       </div>
 
       <div v-else class="d-flex">
-        <v-tooltip
-          :text="$t('components.vocabularyDialogListItem.tooltips.editItem')"
-          location="bottom"
-        >
-          <template #activator="{ props }">
-            <v-btn
-              icon="mdi-pencil"
-              variant="text"
-              size="small"
-              v-bind="props"
-              :aria-label="$t('components.vocabularyDialogListItem.tooltips.editItem')"
-              @click.stop="$emit('edit', item.id)"
-            />
-          </template>
-        </v-tooltip>
+        <v-btn
+          v-tooltip="{
+            text: $t('components.vocabularyDialogListItem.tooltips.editItem'),
+            location: 'bottom'
+          }"
+          icon="mdi-pencil"
+          variant="text"
+          size="small"
+          :aria-label="$t('components.vocabularyDialogListItem.tooltips.editItem')"
+          @click.stop="$emit('edit', item.id)"
+        />
 
-        <v-tooltip
+        <v-btn
           v-if="showExport"
-          :text="$t('components.vocabularyDialogListItem.tooltips.exportItem')"
-          location="bottom"
-        >
-          <template #activator="{ props }">
-            <v-btn
-              icon="mdi-file-export"
-              variant="text"
-              size="small"
-              v-bind="props"
-              :aria-label="$t('components.vocabularyDialogListItem.tooltips.exportItem')"
-              @click.stop="$emit('export', item.id)"
-            />
-          </template>
-        </v-tooltip>
+          v-tooltip="{
+            text: $t('components.vocabularyDialogListItem.tooltips.exportItem'),
+            location: 'bottom'
+          }"
+          icon="mdi-file-export"
+          variant="text"
+          size="small"
+          :aria-label="$t('components.vocabularyDialogListItem.tooltips.exportItem')"
+          @click.stop="$emit('export', item.id)"
+        />
 
-        <v-tooltip
-          :text="$t('components.vocabularyDialogListItem.tooltips.deleteItem')"
-          location="bottom"
-        >
-          <template #activator="{ props }">
-            <v-btn
-              icon="mdi-trash-can"
-              variant="text"
-              size="small"
-              v-bind="props"
-              :aria-label="$t('components.vocabularyDialogListItem.tooltips.deleteItem')"
-              @click.stop="$emit('delete', item.id)"
-            />
-          </template>
-        </v-tooltip>
+        <v-btn
+          v-tooltip="{
+            text: $t('components.vocabularyDialogListItem.tooltips.deleteItem'),
+            location: 'bottom'
+          }"
+          icon="mdi-trash-can"
+          variant="text"
+          size="small"
+          :aria-label="$t('components.vocabularyDialogListItem.tooltips.deleteItem')"
+          @click.stop="$emit('delete', item.id)"
+        />
       </div>
     </template>
   </v-list-item>

--- a/src/renderer/src/components/VocabularyDialogListItem.vue
+++ b/src/renderer/src/components/VocabularyDialogListItem.vue
@@ -16,33 +16,71 @@
 
     <template #append>
       <div v-if="isEditing" class="d-flex">
-        <v-btn
-          icon="mdi-check"
-          variant="text"
-          size="small"
-          @click.stop="$emit('save', editValue)"
-        />
+        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.save')" location="bottom">
+          <template #activator="{ props }">
+            <v-btn
+              icon="mdi-check"
+              variant="text"
+              size="small"
+              v-bind="props"
+              :aria-label="$t('components.vocabularyDialogListItem.tooltips.save')"
+              @click.stop="$emit('save', editValue)"
+            />
+          </template>
+        </v-tooltip>
 
-        <v-btn icon="mdi-close" variant="text" size="small" @click.stop="$emit('cancel')" />
+        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.cancel')" location="bottom">
+          <template #activator="{ props }">
+            <v-btn
+              icon="mdi-close"
+              variant="text"
+              size="small"
+              v-bind="props"
+              :aria-label="$t('components.vocabularyDialogListItem.tooltips.cancel')"
+              @click.stop="$emit('cancel')"
+            />
+          </template>
+        </v-tooltip>
       </div>
 
       <div v-else class="d-flex">
-        <v-btn icon="mdi-pencil" variant="text" size="small" @click.stop="$emit('edit', item.id)" />
+        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.editItem')" location="bottom">
+          <template #activator="{ props }">
+            <v-btn
+              icon="mdi-pencil"
+              variant="text"
+              size="small"
+              v-bind="props"
+              :aria-label="$t('components.vocabularyDialogListItem.tooltips.editItem')"
+              @click.stop="$emit('edit', item.id)"
+            />
+          </template>
+        </v-tooltip>
+        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.exportItem')" location="bottom" v-if="showExport">
+          <template #activator="{ props }">
+            <v-btn
+              icon="mdi-file-export"
+              variant="text"
+              size="small"
+              v-bind="props"
+              :aria-label="$t('components.vocabularyDialogListItem.tooltips.exportItem')"
+              @click.stop="$emit('export', item.id)"
+            />
+          </template>
+        </v-tooltip>
 
-        <v-btn
-          v-if="showExport"
-          icon="mdi-file-export"
-          variant="text"
-          size="small"
-          @click.stop="$emit('export', item.id)"
-        />
-
-        <v-btn
-          icon="mdi-trash-can"
-          variant="text"
-          size="small"
-          @click.stop="$emit('delete', item.id)"
-        />
+        <v-tooltip :text="$t('components.vocabularyDialogListItem.tooltips.deleteItem')" location="bottom">
+          <template #activator="{ props }">
+            <v-btn
+              icon="mdi-trash-can"
+              variant="text"
+              size="small"
+              v-bind="props"
+              :aria-label="$t('components.vocabularyDialogListItem.tooltips.deleteItem')"
+              @click.stop="$emit('delete', item.id)"
+            />
+          </template>
+        </v-tooltip>
       </div>
     </template>
   </v-list-item>

--- a/src/renderer/src/locales/de.json
+++ b/src/renderer/src/locales/de.json
@@ -44,6 +44,14 @@
       "updateAvailable": "Update verfügbar",
       "openVideo": "Video öffnen",
       "importProject": "Projekt importieren",
+
+      "tooltips": {
+        "logout": "Abmelden",
+        "openProject": "Projekt öffnen",
+        "renameProject": "Projekt umbenennen",
+        "deleteProject": "Projekt löschen"
+      },
+
       "renameProject": {
         "title": "Projekt umbenennen",
         "newNameLabel": "Neuer Projektname"
@@ -141,6 +149,16 @@
       }
     },
 
+    "vocabularyDialogListItem": {
+      "tooltips": {
+        "save": "Speichern",
+        "cancel": "Abbrechen",
+        "editItem": "Eintrag bearbeiten",
+        "exportItem": "Eintrag exportieren",
+        "deleteItem": "Eintrag löschen"
+      }
+    },
+
     "shotDetail": {
       "noSelection": "Keine Elemente in der Timeline ausgewählt",
       "multipleSelected": "Mehrere Elemente ausgewählt",
@@ -171,7 +189,32 @@
     },
 
     "videoPlayer": {
-      "playbackRateHelp": "Wiedergabegeschwindigkeit (KL-System)\n\nK: Stopp\nL: Vorwärts abspielen (2x, 4x, 8x, 16x)\n\nMehrfach drücken, um die Geschwindigkeit zu erhöhen"
+      "playbackRateHelp": "Wiedergabegeschwindigkeit anpassen",
+      "tooltips": {
+        "jumpBackward": "5 Sekunden zurückspringen",
+        "previousFrame": "Vorheriges Bild",
+        "playVideo": "Video abspielen",
+        "pausePlayback": "Wiedergabe pausieren",
+        "nextFrame": "Nächstes Bild",
+        "jumpForward": "5 Sekunden vorspringen",
+        "pictureInPicture": "Bild-in-Bild",
+        "takeScreenshot": "Screenshot aufnehmen",
+        "adjustVolume": "Lautstärke anpassen",
+        "unmuteOrAdjustVolume": "Stummschaltung aufheben oder Lautstärke anpassen",
+        "showSubtitles": "Untertitel anzeigen",
+        "hideSubtitles": "Untertitel ausblenden"
+      }
+    },
+
+    "timelines": {
+      "tooltips": {
+        "deleteSelectedSegment": "Ausgewähltes Segment löschen",
+        "splitSelectedSegment": "Ausgewähltes Segment teilen",
+        "mergeSelectedSegments": "Ausgewählte Segmente zusammenführen",
+        "showCategories": "Kategorien anzeigen",
+        "hideCategories": "Kategorien ausblenden",
+        "timelineOptions": "Timeline-Optionen"
+      }
     },
 
     "timelineCanvas": {

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -53,7 +53,13 @@
         "video": "Video",
         "projectFile": "Project file"
       },
-      "uploading": "Video uploading"
+      "uploading": "Video uploading",
+      "tooltips": {
+        "logout": "Logout",
+        "openProject": "Open project",
+        "renameProject": "Rename project",
+        "deleteProject": "Delete project"
+      }
     },
 
     "video": {
@@ -141,6 +147,16 @@
       }
     },
 
+    "vocabularyDialogListItem": {
+      "tooltips": {
+        "save": "Save",
+        "cancel": "Cancel",
+        "editItem": "Edit item",
+        "exportItem": "Export item",
+        "deleteItem": "Delete item"
+      }
+    },
+
     "shotDetail": {
       "noSelection": "No elements in timeline selected",
       "multipleSelected": "Multiple elements selected",
@@ -171,7 +187,32 @@
     },
 
     "videoPlayer": {
-      "playbackRateHelp": "Playback Rate (KL System)\n\nK: Stop\nL: Play forward (2x, 4x, 8x, 16x)\n\nPress multiple times to increase speed"
+      "playbackRateHelp": "Playback Rate (KL System)\n\nK: Stop\nL: Play forward (2x, 4x, 8x, 16x)\n\nPress multiple times to increase speed",
+      "tooltips": {
+        "jumpBackward": "Jump backward 5 seconds",
+        "previousFrame": "Previous frame",
+        "playVideo": "Play video",
+        "pausePlayback": "Pause playback",
+        "nextFrame": "Next frame",
+        "jumpForward": "Jump forward 5 seconds",
+        "pictureInPicture": "Picture in picture",
+        "takeScreenshot": "Take screenshot",
+        "adjustVolume": "Adjust volume",
+        "unmuteOrAdjustVolume": "Unmute or adjust volume",
+        "showSubtitles": "Show subtitles",
+        "hideSubtitles": "Hide subtitles"
+      }
+    },
+
+    "timelines": {
+      "tooltips": {
+        "deleteSelectedSegment": "Delete selected segment",
+        "splitSelectedSegment": "Split selected segment",
+        "mergeSelectedSegments": "Merge selected segments",
+        "showCategories": "Show categories",
+        "hideCategories": "Hide categories",
+        "timelineOptions": "Timeline options"
+      }
     },
 
     "timelineCanvas": {

--- a/src/renderer/src/pages/index.vue
+++ b/src/renderer/src/pages/index.vue
@@ -3,18 +3,14 @@
     <v-app-bar v-if="!electron" density="compact">
       <v-spacer></v-spacer>
 
-      <v-tooltip :text="$t('pages.index.tooltips.logout')" location="bottom">
-        <template #activator="{ props }">
-          <v-btn
-            icon
-            v-bind="props"
-            :aria-label="$t('pages.index.tooltips.logout')"
-            @click="logout"
-          >
-            <v-icon>mdi-logout</v-icon>
-          </v-btn>
-        </template>
-      </v-tooltip>
+      <v-btn
+        v-tooltip="{ text: $t('pages.index.tooltips.logout'), location: 'bottom' }"
+        icon
+        :aria-label="$t('pages.index.tooltips.logout')"
+        @click="logout"
+      >
+        <v-icon>mdi-logout</v-icon>
+      </v-btn>
     </v-app-bar>
 
     <v-main class="fill-height">
@@ -63,44 +59,32 @@
               <v-card-title>{{ project.name }}</v-card-title>
 
               <v-card-actions>
-                <v-tooltip :text="$t('pages.index.tooltips.openProject')" location="bottom">
-                  <template #activator="{ props }">
-                    <v-btn
-                      icon
-                      v-bind="props"
-                      :aria-label="$t('pages.index.tooltips.openProject')"
-                      @click.stop="openProject(project.id)"
-                    >
-                      <v-icon>mdi-movie-search-outline</v-icon>
-                    </v-btn>
-                  </template>
-                </v-tooltip>
+                <v-btn
+                  v-tooltip="{ text: $t('pages.index.tooltips.openProject'), location: 'bottom' }"
+                  icon
+                  :aria-label="$t('pages.index.tooltips.openProject')"
+                  @click.stop="openProject(project.id)"
+                >
+                  <v-icon>mdi-movie-search-outline</v-icon>
+                </v-btn>
 
-                <v-tooltip :text="$t('pages.index.tooltips.renameProject')" location="bottom">
-                  <template #activator="{ props }">
-                    <v-btn
-                      icon
-                      v-bind="props"
-                      :aria-label="$t('pages.index.tooltips.renameProject')"
-                      @click.stop="changeProjectName(project)"
-                    >
-                      <v-icon>mdi-pencil</v-icon>
-                    </v-btn>
-                  </template>
-                </v-tooltip>
+                <v-btn
+                  v-tooltip="{ text: $t('pages.index.tooltips.renameProject'), location: 'bottom' }"
+                  icon
+                  :aria-label="$t('pages.index.tooltips.renameProject')"
+                  @click.stop="changeProjectName(project)"
+                >
+                  <v-icon>mdi-pencil</v-icon>
+                </v-btn>
 
-                <v-tooltip :text="$t('pages.index.tooltips.deleteProject')" location="bottom">
-                  <template #activator="{ props }">
-                    <v-btn
-                      icon
-                      v-bind="props"
-                      :aria-label="$t('pages.index.tooltips.deleteProject')"
-                      @click.stop="deleteProject(project.id)"
-                    >
-                      <v-icon>mdi-delete</v-icon>
-                    </v-btn>
-                  </template>
-                </v-tooltip>
+                <v-btn
+                  v-tooltip="{ text: $t('pages.index.tooltips.deleteProject'), location: 'bottom' }"
+                  icon
+                  :aria-label="$t('pages.index.tooltips.deleteProject')"
+                  @click.stop="deleteProject(project.id)"
+                >
+                  <v-icon>mdi-delete</v-icon>
+                </v-btn>
               </v-card-actions>
             </v-card>
           </v-col>

--- a/src/renderer/src/pages/index.vue
+++ b/src/renderer/src/pages/index.vue
@@ -3,9 +3,20 @@
     <v-app-bar v-if="!electron" density="compact">
       <v-spacer></v-spacer>
 
-      <v-btn icon @click="logout">
-        <v-icon>mdi-logout</v-icon>
-      </v-btn>
+      <v-tooltip :text="$t('pages.index.tooltips.logout')" location="bottom">
+        <template #activator="{ props }">
+          <v-btn
+            icon
+            v-bind="props"
+            @click="logout"
+            :aria-label="$t('pages.index.tooltips.logout')"
+          >
+            <v-icon>mdi-logout</v-icon>
+          </v-btn>
+        </template>
+      </v-tooltip>
+
+      
     </v-app-bar>
 
     <v-main class="fill-height">
@@ -54,17 +65,48 @@
               <v-card-title>{{ project.name }}</v-card-title>
 
               <v-card-actions>
-                <v-btn icon @click.stop="openProject(project.id)">
-                  <v-icon>mdi-movie-search-outline</v-icon>
-                </v-btn>
 
-                <v-btn icon @click.stop="changeProjectName(project)">
-                  <v-icon>mdi-pencil</v-icon>
-                </v-btn>
+                <v-tooltip :text="$t('pages.index.tooltips.openProject')" location="bottom">
+                  <template #activator="{ props }">
+                    <v-btn
+                      icon
+                      v-bind="props"
+                      @click.stop="openProject(project.id)"
+                      :aria-label="$t('pages.index.tooltips.openProject')"
+                    >
+                      <v-icon>mdi-movie-search-outline</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
 
-                <v-btn icon @click.stop="deleteProject(project.id)">
-                  <v-icon>mdi-delete</v-icon>
-                </v-btn>
+                <v-tooltip :text="$t('pages.index.tooltips.renameProject')" location="bottom">
+                  <template #activator="{ props }">
+                    <v-btn
+                      icon
+                      v-bind="props"
+                      @click.stop="changeProjectName(project)"
+                      :aria-label="$t('pages.index.tooltips.renameProject')"
+                    >
+                      <v-icon>mdi-pencil</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+
+
+
+                <v-tooltip :text="$t('pages.index.tooltips.deleteProject')" location="bottom">
+                  <template #activator="{ props }">
+                    <v-btn
+                      icon
+                      v-bind="props"
+                      @click.stop="deleteProject(project.id)"
+                      :aria-label="$t('pages.index.tooltips.deleteProject')"
+                    >
+                      <v-icon>mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+
               </v-card-actions>
             </v-card>
           </v-col>

--- a/src/renderer/src/pages/index.vue
+++ b/src/renderer/src/pages/index.vue
@@ -8,15 +8,13 @@
           <v-btn
             icon
             v-bind="props"
-            @click="logout"
             :aria-label="$t('pages.index.tooltips.logout')"
+            @click="logout"
           >
             <v-icon>mdi-logout</v-icon>
           </v-btn>
         </template>
       </v-tooltip>
-
-      
     </v-app-bar>
 
     <v-main class="fill-height">
@@ -65,14 +63,13 @@
               <v-card-title>{{ project.name }}</v-card-title>
 
               <v-card-actions>
-
                 <v-tooltip :text="$t('pages.index.tooltips.openProject')" location="bottom">
                   <template #activator="{ props }">
                     <v-btn
                       icon
                       v-bind="props"
-                      @click.stop="openProject(project.id)"
                       :aria-label="$t('pages.index.tooltips.openProject')"
+                      @click.stop="openProject(project.id)"
                     >
                       <v-icon>mdi-movie-search-outline</v-icon>
                     </v-btn>
@@ -84,29 +81,26 @@
                     <v-btn
                       icon
                       v-bind="props"
-                      @click.stop="changeProjectName(project)"
                       :aria-label="$t('pages.index.tooltips.renameProject')"
+                      @click.stop="changeProjectName(project)"
                     >
                       <v-icon>mdi-pencil</v-icon>
                     </v-btn>
                   </template>
                 </v-tooltip>
 
-
-
                 <v-tooltip :text="$t('pages.index.tooltips.deleteProject')" location="bottom">
                   <template #activator="{ props }">
                     <v-btn
                       icon
                       v-bind="props"
-                      @click.stop="deleteProject(project.id)"
                       :aria-label="$t('pages.index.tooltips.deleteProject')"
+                      @click.stop="deleteProject(project.id)"
                     >
                       <v-icon>mdi-delete</v-icon>
                     </v-btn>
                   </template>
                 </v-tooltip>
-
               </v-card-actions>
             </v-card>
           </v-col>


### PR DESCRIPTION
## Summary
Added tooltips with i18n support across multiple UI components.

## Changes
- Replaced hardcoded tooltip text with `$t(...)`
- Added translation keys to `en.json` and `de.json`
- Added `aria-label` for accessibility

## Notes
- UI improvement only
- No functional logic changes