### PR TITLE
Shot Boundary Detection Async Bug

### DIFF
--- a/src/renderer/src/stores/undoable.js
+++ b/src/renderer/src/stores/undoable.js
@@ -247,6 +247,7 @@ export const useUndoableStore = defineStore('undoable', {
       })
     },
     onShotBoundaryDetection(data) {
+      if (this.id !== this.detectionProjectId) return
       this.timelines.push({
         data: data.map((shot) => ({
           annotation: '',
@@ -291,6 +292,7 @@ export const useUndoableStore = defineStore('undoable', {
       this.timelines = items
     },
     runShotBoundaryDetection() {
+      this.detectionProjectId = this.id
       api.runShotBoundaryDetection(useMainStore().video)
     },
     splitSegment(timelineId, segmentId, position) {


### PR DESCRIPTION
Avoid a bug where if you start shot boundary detection in one project and switch over to another project, the detected boundaries will be inserted into the new project.

This just dumps the detected boundaries which seems like the easiest fix for now.

