### PR TITLE
Cancel all running jobs when switching projects

### DIFF
--- a/src/renderer/src/pages/videoanalysis/[id].vue
+++ b/src/renderer/src/pages/videoanalysis/[id].vue
@@ -408,6 +408,9 @@ export default {
     shortcuts.clear('z', true, true)
     shortcuts.clear('z', true, false, true)
     shortcuts.clear('z', false, false, true)
+    this.tempStore.jobs
+      .filter((j) => j.status === 'RUNNING')
+      .forEach((j) => this.tempStore.terminateJob(j.id))
     api.unregisterVideoViewCallbacks()
   },
 

--- a/src/renderer/src/stores/undoable.js
+++ b/src/renderer/src/stores/undoable.js
@@ -247,6 +247,7 @@ export const useUndoableStore = defineStore('undoable', {
       })
     },
     onShotBoundaryDetection(data) {
+      if (this.id !== this.detectionProjectId) return
       this.timelines.push({
         data: data.map((shot) => ({
           annotation: '',
@@ -291,6 +292,7 @@ export const useUndoableStore = defineStore('undoable', {
       this.timelines = items
     },
     runShotBoundaryDetection() {
+      this.detectionProjectId = this.id
       api.runShotBoundaryDetection(useMainStore().video)
     },
     splitSegment(timelineId, segmentId, position) {

--- a/src/renderer/src/stores/undoable.js
+++ b/src/renderer/src/stores/undoable.js
@@ -247,7 +247,6 @@ export const useUndoableStore = defineStore('undoable', {
       })
     },
     onShotBoundaryDetection(data) {
-      if (this.id !== this.detectionProjectId) return
       this.timelines.push({
         data: data.map((shot) => ({
           annotation: '',
@@ -292,7 +291,6 @@ export const useUndoableStore = defineStore('undoable', {
       this.timelines = items
     },
     runShotBoundaryDetection() {
-      this.detectionProjectId = this.id
       api.runShotBoundaryDetection(useMainStore().video)
     },
     splitSegment(timelineId, segmentId, position) {


### PR DESCRIPTION
Added code to cancel all running jobs in beforeUnmount instead of guarding per job type, as suggested in PR #43.